### PR TITLE
Accent the main post in a CollectionView

### DIFF
--- a/src/Content/PostItem.vala
+++ b/src/Content/PostItem.vala
@@ -86,6 +86,9 @@ public class PostItem : Gtk.Widget {
       content_box.margin_top     = set_display_mode != LIST ? 8 : 0;
 
       DisplayUtils.conditional_css (set_display_mode == QUOTE, text_label, "caption");
+      if (this.parent != null) {
+        DisplayUtils.conditional_css (set_display_mode == MAIN, this.parent, "main-post");
+      }
     }
   }
 

--- a/ui/style.css
+++ b/ui/style.css
@@ -212,6 +212,23 @@ listview.post-list.small > row {
 }
 
 /**
+ * Give the PostItem for a main post an accented background.
+ */
+listview.post-list > row.main-post {
+  background-color: alpha(@accent_color, 0.12);
+  margin: 6px 0px;
+}
+listview.post-list.small > row.main-post {
+  margin: 0px;
+}
+listview.post-list > row.main-post:hover {
+  background-color: alpha(@accent_color, 0.2);
+}
+listview.post-list > row.main-post:active {
+  background-color: alpha(@accent_color, 0.32);
+}
+
+/**
  * Styles for preferences rows doing a destructive action.
  */
 row.destructive-action {


### PR DESCRIPTION
Since all posts are displayed quite similar in the current style, it might make sense to accent the "main post" so it is clearly recognizable in a Thread view.

This branch colors the background of the main post in the accent color:

![main-post](https://user-images.githubusercontent.com/47981497/194135320-d7de93f8-1301-46f6-94a2-30c249d80956.png)

While this works in focusing the main post, it might be worth discussing other designs for focusing the post before settling on this, hence this PR.