### PR TITLE
Favourite and boost posts

### DIFF
--- a/data/icons/icons.gresource.xml
+++ b/data/icons/icons.gresource.xml
@@ -13,6 +13,7 @@
     <file>scalable/actions/reload-symbolic.svg</file>
     <file>scalable/actions/reply-symbolic.svg</file>
     <file>scalable/actions/repost-symbolic.svg</file>
+    <file>scalable/actions/reposted-symbolic.svg</file>
     <file>scalable/actions/stopwatch-symbolic.svg</file>
     <file>scalable/actions/verified-symbolic.svg</file>
   </gresource>

--- a/data/icons/scalable/actions/repost-symbolic.svg
+++ b/data/icons/scalable/actions/repost-symbolic.svg
@@ -23,7 +23,7 @@
      inkscape:pagecheckerboard="1"
      showgrid="false"
      inkscape:zoom="25.0625"
-     inkscape:cx="3.2917706"
+     inkscape:cx="3.3715711"
      inkscape:cy="15.062344"
      inkscape:window-width="2560"
      inkscape:window-height="1372"
@@ -42,15 +42,11 @@
     <g
        stroke-width="1.98819"
        id="g12"
-       transform="translate(0,5.3513327e-4)" />
-    <g
-       stroke-width="1.98819"
-       id="g12-6"
-       transform="translate(2.4913649e-4,0.78340438)">
+       transform="matrix(1.0048041,0,0,1,-29.537016,0.96722218)">
       <g
          id="g6109">
         <path
-           d="m 6154.6518,1461.2307 -0.028,-1.573 -9.9622,-0.027 c -2.135,-0.6239 -1.8071,-3.6229 -0.4561,-4.5383 l -0.8575,-0.9532 c -3.1875,2.1382 -1.532,7.0767 1.621,7.0618 z"
+           d="m 6154.9125,1461.4023 v -1.5416 h -10.2281 c 0,0 -1.6355,-0.2887 -1.6506,-2.0554 -0.015,-1.7667 1.1392,-2.5693 1.1392,-2.5693 l -1.0228,-1.0278 c 0,0 -1.5249,0.4715 -1.5129,3.5971 0.012,3.1256 3.0471,3.597 3.0471,3.597 z"
            font-variant-ligatures="normal"
            font-variant-position="normal"
            font-variant-caps="normal"
@@ -68,22 +64,23 @@
            isolation="auto"
            mix-blend-mode="normal"
            id="path8"
-           sodipodi:nodetypes="ccccccc" />
+           sodipodi:nodetypes="ccczcczcc" />
         <path
-           d="m 6152.1287,1463.7835 -0.011,-0.6055 c 0,-0.2486 0.1258,-0.5117 0.3028,-0.6954 l 1.8752,-2.0367 -1.8388,-2.0064 c -0.1761,-0.1838 -0.2913,-0.4471 -0.3028,-0.6965 l -0.03,-0.6439 h 0.4297 c 0.2998,9e-4 0.5339,0.087 0.7254,0.2728 l 2.6688,3.0745 -2.8125,3.0778 c -0.1915,0.1838 -0.4256,0.2708 -0.7254,0.2708 z"
+           d="m 6152.1159,1463.9604 -0.011,-0.6055 c 0,-0.2486 0.1258,-0.5117 0.3028,-0.6954 l 1.8753,-2.0367 -1.8389,-2.0064 c -0.1761,-0.1838 -0.2913,-0.4471 -0.3028,-0.6965 l -0.03,-0.6439 h 0.4297 c 0.2998,9e-4 0.534,0.087 0.7255,0.2728 l 2.6688,3.0745 -2.8125,3.0778 c -0.1916,0.1838 -0.4257,0.2708 -0.7255,0.2708 z"
            text-indent="0"
            text-align="start"
            text-decoration-line="none"
            text-transform="none"
            id="path10"
-           sodipodi:nodetypes="cscccscsccccc" />
+           sodipodi:nodetypes="cscccscsccccc"
+           style="stroke-width:1.98822" />
       </g>
     </g>
     <use
        x="0"
        y="0"
-       xlink:href="#g12-6"
+       xlink:href="#g12"
        id="use6156"
-       transform="rotate(180,6149.8106,1457.6327)" />
+       transform="rotate(180,6149.8139,1457.7365)" />
   </g>
 </svg>

--- a/data/icons/scalable/actions/repost-symbolic.svg
+++ b/data/icons/scalable/actions/repost-symbolic.svg
@@ -9,6 +9,7 @@
    id="svg16"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg">
   <defs
@@ -21,15 +22,15 @@
      inkscape:pageopacity="0"
      inkscape:pagecheckerboard="1"
      showgrid="false"
-     inkscape:zoom="141.77491"
-     inkscape:cx="2.380534"
-     inkscape:cy="6.1893884"
+     inkscape:zoom="25.0625"
+     inkscape:cx="3.2917706"
+     inkscape:cy="15.062344"
      inkscape:window-width="2560"
      inkscape:window-height="1372"
      inkscape:window-x="0"
      inkscape:window-y="32"
      inkscape:window-maximized="1"
-     inkscape:current-layer="g12"
+     inkscape:current-layer="g14"
      id="namedview2"
      inkscape:showpageshadow="2"
      inkscape:deskcolor="#d1d1d1" />
@@ -38,66 +39,51 @@
      stroke-width="2.05545"
      transform="matrix(0.97302294 0 0 0.97302255 -5975.9018 -1410.419)"
      id="g14">
-    <path
-       d="m 6146.3151,1453.4317 v 1.9346 h 8.3267 c 0.8126,0 1.451,0.6384 1.451,1.4509 0,0.8125 -0.2583,1.0269 -0.8995,1.4724 l -0.3375,0.2346 1.3669,1.3599 0.3723,-0.262 c 0.4634,-0.3262 1.4323,-0.9468 1.4323,-2.8049 0,-1.8581 -1.5273,-3.3855 -3.3855,-3.3855 z"
-       stroke-width="1.98818"
-       font-variant-ligatures="normal"
-       font-variant-position="normal"
-       font-variant-caps="normal"
-       font-variant-numeric="normal"
-       font-variant-alternates="normal"
-       font-feature-settings="normal"
-       text-indent="0"
-       text-align="start"
-       text-decoration-line="none"
-       text-decoration-style="solid"
-       text-decoration-color="#000000"
-       text-transform="none"
-       text-orientation="mixed"
-       shape-padding="0"
-       isolation="auto"
-       mix-blend-mode="normal"
-       id="path4"
-       sodipodi:nodetypes="ccsssccsssc" />
-    <path
-       d="m 6148.8682,1450.5512 v 0.9673 c 0,0.2486 -0.1258,0.5117 -0.3028,0.6954 l -2.2054,2.2064 2.2054,2.2063 c 0.1761,0.1838 0.3028,0.4469 0.3028,0.6965 v 0.9673 h -0.9673 c -0.2998,0 -0.5339,-0.087 -0.7254,-0.2728 l -3.5364,-3.5973 3.5364,-3.5973 c 0.1915,-0.1838 0.4256,-0.2708 0.7254,-0.2708 z"
-       stroke-width="1.98818"
-       text-indent="0"
-       text-align="start"
-       text-decoration-line="none"
-       text-transform="none"
-       id="path6" />
     <g
        stroke-width="1.98819"
        id="g12"
-       transform="translate(0,5.3513327e-4)">
-      <path
-         d="m 6153.4323,1461.2013 v -1.9346 h -8.4631 c -0.8126,0 -1.451,-0.6384 -1.451,-1.4509 0,-0.8125 0.3942,-1.2086 0.5985,-1.3498 l 0.4383,-0.3028 -1.2955,-1.3913 -0.2842,0.2117 c -0.4363,0.325 -1.3916,0.9741 -1.3916,2.8322 0,1.8581 1.5273,3.3855 3.3855,3.3855 z"
-         font-variant-ligatures="normal"
-         font-variant-position="normal"
-         font-variant-caps="normal"
-         font-variant-numeric="normal"
-         font-variant-alternates="normal"
-         font-feature-settings="normal"
-         text-indent="0"
-         text-align="start"
-         text-decoration-line="none"
-         text-decoration-style="solid"
-         text-decoration-color="#000000"
-         text-transform="none"
-         text-orientation="mixed"
-         shape-padding="0"
-         isolation="auto"
-         mix-blend-mode="normal"
-         id="path8"
-         sodipodi:nodetypes="ccsssccsssc" />
-      <path
-         d="m 6150.7181,1464.0818 v -0.9673 c 0,-0.2486 0.1258,-0.5117 0.3028,-0.6954 l 2.2054,-2.2064 -2.2054,-2.2063 c -0.1761,-0.1838 -0.3028,-0.4469 -0.3028,-0.6965 v -0.9673 h 0.9673 c 0.2998,0 0.5339,0.087 0.7254,0.2728 l 3.5364,3.5973 -3.5364,3.5973 c -0.1915,0.1838 -0.4256,0.2708 -0.7254,0.2708 z"
-         text-indent="0"
-         text-align="start"
-         text-decoration-line="none"
-         text-transform="none"
-         id="path10" />
+       transform="translate(0,5.3513327e-4)" />
+    <g
+       stroke-width="1.98819"
+       id="g12-6"
+       transform="translate(2.4913649e-4,0.78340438)">
+      <g
+         id="g6109">
+        <path
+           d="m 6154.6518,1461.2307 -0.028,-1.573 -9.9622,-0.027 c -2.135,-0.6239 -1.8071,-3.6229 -0.4561,-4.5383 l -0.8575,-0.9532 c -3.1875,2.1382 -1.532,7.0767 1.621,7.0618 z"
+           font-variant-ligatures="normal"
+           font-variant-position="normal"
+           font-variant-caps="normal"
+           font-variant-numeric="normal"
+           font-variant-alternates="normal"
+           font-feature-settings="normal"
+           text-indent="0"
+           text-align="start"
+           text-decoration-line="none"
+           text-decoration-style="solid"
+           text-decoration-color="#000000"
+           text-transform="none"
+           text-orientation="mixed"
+           shape-padding="0"
+           isolation="auto"
+           mix-blend-mode="normal"
+           id="path8"
+           sodipodi:nodetypes="ccccccc" />
+        <path
+           d="m 6152.1287,1463.7835 -0.011,-0.6055 c 0,-0.2486 0.1258,-0.5117 0.3028,-0.6954 l 1.8752,-2.0367 -1.8388,-2.0064 c -0.1761,-0.1838 -0.2913,-0.4471 -0.3028,-0.6965 l -0.03,-0.6439 h 0.4297 c 0.2998,9e-4 0.5339,0.087 0.7254,0.2728 l 2.6688,3.0745 -2.8125,3.0778 c -0.1915,0.1838 -0.4256,0.2708 -0.7254,0.2708 z"
+           text-indent="0"
+           text-align="start"
+           text-decoration-line="none"
+           text-transform="none"
+           id="path10"
+           sodipodi:nodetypes="cscccscsccccc" />
+      </g>
     </g>
+    <use
+       x="0"
+       y="0"
+       xlink:href="#g12-6"
+       id="use6156"
+       transform="rotate(180,6149.8106,1457.6327)" />
   </g>
 </svg>

--- a/data/icons/scalable/actions/repost-symbolic.svg
+++ b/data/icons/scalable/actions/repost-symbolic.svg
@@ -3,84 +3,52 @@
    height="16px"
    viewBox="0 0 16 16"
    width="16px"
+   version="1.1"
+   id="svg734"
    sodipodi:docname="repost-symbolic.svg"
    inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
-   version="1.1"
-   id="svg16"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg">
   <defs
-     id="defs18" />
+     id="defs738" />
   <sodipodi:namedview
+     id="namedview736"
      pagecolor="#ffffff"
-     bordercolor="#111111"
-     borderopacity="1"
-     inkscape:pageshadow="0"
-     inkscape:pageopacity="0"
-     inkscape:pagecheckerboard="1"
-     showgrid="false"
-     inkscape:zoom="25.0625"
-     inkscape:cx="3.3715711"
-     inkscape:cy="15.062344"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="true"
+     inkscape:zoom="29.5"
+     inkscape:cx="-0.59322034"
+     inkscape:cy="9.8135593"
      inkscape:window-width="2560"
      inkscape:window-height="1372"
      inkscape:window-x="0"
      inkscape:window-y="32"
      inkscape:window-maximized="1"
-     inkscape:current-layer="g14"
-     id="namedview2"
-     inkscape:showpageshadow="2"
-     inkscape:deskcolor="#d1d1d1" />
+     inkscape:current-layer="g732">
+    <inkscape:grid
+       type="xygrid"
+       id="grid884" />
+  </sodipodi:namedview>
   <g
-     fill="#474747"
-     stroke-width="2.05545"
-     transform="matrix(0.97302294 0 0 0.97302255 -5975.9018 -1410.419)"
-     id="g14">
-    <g
-       stroke-width="1.98819"
-       id="g12"
-       transform="matrix(1.0048041,0,0,1,-29.537016,0.96722218)">
-      <g
-         id="g6109">
-        <path
-           d="m 6154.9125,1461.4023 v -1.5416 h -10.2281 c 0,0 -1.6355,-0.2887 -1.6506,-2.0554 -0.015,-1.7667 1.1392,-2.5693 1.1392,-2.5693 l -1.0228,-1.0278 c 0,0 -1.5249,0.4715 -1.5129,3.5971 0.012,3.1256 3.0471,3.597 3.0471,3.597 z"
-           font-variant-ligatures="normal"
-           font-variant-position="normal"
-           font-variant-caps="normal"
-           font-variant-numeric="normal"
-           font-variant-alternates="normal"
-           font-feature-settings="normal"
-           text-indent="0"
-           text-align="start"
-           text-decoration-line="none"
-           text-decoration-style="solid"
-           text-decoration-color="#000000"
-           text-transform="none"
-           text-orientation="mixed"
-           shape-padding="0"
-           isolation="auto"
-           mix-blend-mode="normal"
-           id="path8"
-           sodipodi:nodetypes="ccczcczcc" />
-        <path
-           d="m 6152.1159,1463.9604 -0.011,-0.6055 c 0,-0.2486 0.1258,-0.5117 0.3028,-0.6954 l 1.8753,-2.0367 -1.8389,-2.0064 c -0.1761,-0.1838 -0.2913,-0.4471 -0.3028,-0.6965 l -0.03,-0.6439 h 0.4297 c 0.2998,9e-4 0.534,0.087 0.7255,0.2728 l 2.6688,3.0745 -2.8125,3.0778 c -0.1916,0.1838 -0.4257,0.2708 -0.7255,0.2708 z"
-           text-indent="0"
-           text-align="start"
-           text-decoration-line="none"
-           text-transform="none"
-           id="path10"
-           sodipodi:nodetypes="cscccscsccccc"
-           style="stroke-width:1.98822" />
-      </g>
-    </g>
+     fill="#2e3436"
+     id="g732">
+    <path
+       d="m 5,2.0000943 c 0,0 -0.707031,-0.015625 -1.449219,0.355469 C 2.8125,2.7266563 2,3.6680633 2,5.0000943 l 0.011942,3.0079589 h -2 v 1 h 0.0078125 c -0.0039063,0.265625 0.1015625,0.519531 0.2851565,0.707031 l 2,1.9999998 c 0.390625,0.390625 1.023437,0.390625 1.414062,0 l 2,-1.9999998 c 0.183594,-0.1875 0.289063,-0.441406 0.289063,-0.707031 h 0.00391 v -1 h -2 V 4.8853291 C 4.1174112,4.0845481 4.5,4.0000943 5,4.0000943 h 5 c 0.550781,0 1,-0.449219 1,-1 0,-0.550781 -0.449219,-1 -1,-1 z"
+       id="path730"
+       sodipodi:nodetypes="ccscccccssccccccssssc" />
     <use
        x="0"
        y="0"
-       xlink:href="#g12"
-       id="use6156"
-       transform="rotate(180,6149.8139,1457.7365)" />
+       xlink:href="#path730"
+       id="use886"
+       transform="rotate(180,8,8.0614089)" />
   </g>
 </svg>

--- a/data/icons/scalable/actions/reposted-symbolic.svg
+++ b/data/icons/scalable/actions/reposted-symbolic.svg
@@ -9,6 +9,7 @@
    id="svg16"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg">
   <defs
@@ -21,9 +22,9 @@
      inkscape:pageopacity="0"
      inkscape:pagecheckerboard="1"
      showgrid="false"
-     inkscape:zoom="141.77491"
-     inkscape:cx="0.92752659"
-     inkscape:cy="8.0091744"
+     inkscape:zoom="35.443728"
+     inkscape:cx="23.544363"
+     inkscape:cy="18.691601"
      inkscape:window-width="2560"
      inkscape:window-height="1372"
      inkscape:window-x="0"
@@ -40,69 +41,56 @@
      id="g14">
     <path
        style="fill:#4d4d4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.02773px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 6144.7824,1456.411 2.3339,2.2727 2.181,0.013 -0.01,-1.9037 -1.012,-1.074 6.3024,-0 c 1.1321,0.6681 1.3394,1.606 -0.031,2.45 l -2.1993,-2.1847 -2.0641,-0 0.01,1.9069 0.9775,1.0529 -6.1218,-0.016 c -1.5404,-0.7325 -1.1337,-1.5801 -0.5627,-2.3655 z"
+       d="m 6144.7824,1456.4182 1.6775,1.7667 1.6643,0.011 0.033,-2.0523 -0.5371,-0.6373 2.1924,0.01 -0.015,4.1509 -4.9182,-0.01 c 0,0 -1.0325,-0.2139 -1.0156,-1.5185 0.017,-1.3046 0.9187,-1.7205 0.9187,-1.7205 z"
        id="path475"
-       sodipodi:nodetypes="cccccccccccccc" />
-    <path
-       d="m 6146.3151,1453.4317 v 1.9346 h 8.3267 c 0.8126,0 1.451,0.6384 1.451,1.4509 0,0.8125 -0.2583,1.0269 -0.8995,1.4724 l -0.3375,0.2346 1.3669,1.3599 0.3723,-0.262 c 0.4634,-0.3262 1.4323,-0.9468 1.4323,-2.8049 0,-1.8581 -1.5273,-3.3855 -3.3855,-3.3855 z"
-       stroke-width="1.98818"
-       font-variant-ligatures="normal"
-       font-variant-position="normal"
-       font-variant-caps="normal"
-       font-variant-numeric="normal"
-       font-variant-alternates="normal"
-       font-feature-settings="normal"
-       text-indent="0"
-       text-align="start"
-       text-decoration-line="none"
-       text-decoration-style="solid"
-       text-decoration-color="#000000"
-       text-transform="none"
-       text-orientation="mixed"
-       shape-padding="0"
-       isolation="auto"
-       mix-blend-mode="normal"
-       id="path4"
-       sodipodi:nodetypes="ccsssccsssc" />
-    <path
-       d="m 6148.8682,1450.5512 v 0.9673 c 0,0.2486 -0.1258,0.5117 -0.3028,0.6954 l -2.2054,2.2064 2.2054,2.2063 c 0.1761,0.1838 0.3028,0.4469 0.3028,0.6965 v 0.9673 h -0.9673 c -0.2998,0 -0.5339,-0.087 -0.7254,-0.2728 l -3.5364,-3.5973 3.5364,-3.5973 c 0.1915,-0.1838 0.4256,-0.2708 0.7254,-0.2708 z"
-       stroke-width="1.98818"
-       text-indent="0"
-       text-align="start"
-       text-decoration-line="none"
-       text-transform="none"
-       id="path6" />
+       sodipodi:nodetypes="cccccccczc" />
     <g
        stroke-width="1.98819"
        id="g12"
-       transform="translate(-2.8807212e-5,4.7729717e-4)">
-      <path
-         d="m 6153.4323,1461.2013 v -1.9346 h -8.4631 c -0.8126,0 -1.451,-0.6384 -1.451,-1.4509 0,-0.8125 0.4794,-1.2675 0.5985,-1.3498 l 0.4383,-0.3028 -1.2955,-1.3913 -0.2842,0.2117 c -0.4363,0.325 -1.3916,0.9741 -1.3916,2.8322 0,1.8581 1.5273,3.3855 3.3855,3.3855 z"
-         font-variant-ligatures="normal"
-         font-variant-position="normal"
-         font-variant-caps="normal"
-         font-variant-numeric="normal"
-         font-variant-alternates="normal"
-         font-feature-settings="normal"
-         text-indent="0"
-         text-align="start"
-         text-decoration-line="none"
-         text-decoration-style="solid"
-         text-decoration-color="#000000"
-         text-transform="none"
-         text-orientation="mixed"
-         shape-padding="0"
-         isolation="auto"
-         mix-blend-mode="normal"
-         id="path8"
-         sodipodi:nodetypes="ccsssccsssc" />
-      <path
-         d="m 6150.7181,1464.0818 v -0.9673 c 0,-0.2486 0.1258,-0.5117 0.3028,-0.6954 l 2.2054,-2.2064 -2.2054,-2.2063 c -0.1761,-0.1838 -0.3028,-0.4469 -0.3028,-0.6965 v -0.9673 h 0.9673 c 0.2998,0 0.5339,0.087 0.7254,0.2728 l 3.5364,3.5973 -3.5364,3.5973 c -0.1915,0.1838 -0.4256,0.2708 -0.7254,0.2708 z"
-         text-indent="0"
-         text-align="start"
-         text-decoration-line="none"
-         text-transform="none"
-         id="path10" />
+       transform="translate(-2.8807212e-5,0.78336847)">
+      <g
+         id="g6109">
+        <path
+           d="m 6154.6518,1461.2307 -0.028,-1.573 -9.9622,-0.027 c -2.135,-0.6239 -1.8071,-3.6229 -0.4561,-4.5383 l -0.8575,-0.9532 c -3.1875,2.1382 -1.532,7.0767 1.621,7.0618 z"
+           font-variant-ligatures="normal"
+           font-variant-position="normal"
+           font-variant-caps="normal"
+           font-variant-numeric="normal"
+           font-variant-alternates="normal"
+           font-feature-settings="normal"
+           text-indent="0"
+           text-align="start"
+           text-decoration-line="none"
+           text-decoration-style="solid"
+           text-decoration-color="#000000"
+           text-transform="none"
+           text-orientation="mixed"
+           shape-padding="0"
+           isolation="auto"
+           mix-blend-mode="normal"
+           id="path8"
+           sodipodi:nodetypes="ccccccc" />
+        <path
+           d="m 6152.1287,1463.7835 -0.011,-0.6055 c 0,-0.2486 0.1258,-0.5117 0.3028,-0.6954 l 1.8752,-2.0367 -1.8388,-2.0064 c -0.1761,-0.1838 -0.2913,-0.4471 -0.3028,-0.6965 l -0.03,-0.6439 h 0.4297 c 0.2998,9e-4 0.5339,0.087 0.7254,0.2728 l 2.6688,3.0745 -2.8125,3.0778 c -0.1915,0.1838 -0.4256,0.2708 -0.7254,0.2708 z"
+           text-indent="0"
+           text-align="start"
+           text-decoration-line="none"
+           text-transform="none"
+           id="path10"
+           sodipodi:nodetypes="cscccscsccccc" />
+      </g>
     </g>
+    <use
+       x="0"
+       y="0"
+       xlink:href="#g12"
+       id="use6156"
+       transform="rotate(180,6149.8102,1457.6325)" />
+    <use
+       x="0"
+       y="0"
+       xlink:href="#path475"
+       id="use6158"
+       transform="rotate(180,6149.7549,1457.591)" />
   </g>
 </svg>

--- a/data/icons/scalable/actions/reposted-symbolic.svg
+++ b/data/icons/scalable/actions/reposted-symbolic.svg
@@ -3,109 +3,63 @@
    height="16px"
    viewBox="0 0 16 16"
    width="16px"
+   version="1.1"
+   id="svg734"
    sodipodi:docname="reposted-symbolic.svg"
    inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
-   version="1.1"
-   id="svg16"
-   inkscape:export-filename="reposted-symbolic.png"
-   inkscape:export-xdpi="96"
-   inkscape:export-ydpi="96"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg">
   <defs
-     id="defs18" />
+     id="defs738" />
   <sodipodi:namedview
+     id="namedview736"
      pagecolor="#ffffff"
-     bordercolor="#111111"
-     borderopacity="1"
-     inkscape:pageshadow="0"
-     inkscape:pageopacity="0"
-     inkscape:pagecheckerboard="1"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
      showgrid="true"
-     inkscape:zoom="128"
-     inkscape:cx="7.3476562"
-     inkscape:cy="6.8476562"
+     inkscape:zoom="83.4386"
+     inkscape:cx="11.451534"
+     inkscape:cy="7.4246212"
      inkscape:window-width="2560"
      inkscape:window-height="1372"
      inkscape:window-x="0"
      inkscape:window-y="32"
      inkscape:window-maximized="1"
-     inkscape:current-layer="g14"
-     id="namedview2"
-     inkscape:showpageshadow="2"
-     inkscape:deskcolor="#d1d1d1"
-     showguides="true">
+     inkscape:current-layer="g732">
     <inkscape:grid
        type="xygrid"
-       id="grid794"
-       dotted="true"
-       spacingx="1"
-       spacingy="1"
-       empspacing="4"
-       originx="0"
-       originy="0" />
+       id="grid884" />
   </sodipodi:namedview>
   <g
-     fill="#474747"
-     stroke-width="2.05545"
-     transform="matrix(0.97302294 0 0 0.97302255 -5975.9018 -1410.419)"
-     id="g14">
+     fill="#2e3436"
+     id="g732">
     <path
-       style="fill:#4d4d4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.02773px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 6144.8107,1456.9734 1.295,1.2857 h 2.672 v -1.5416 l -0.5138,-1.0142 1.6443,-0.013 v 4.1109 l -4.9533,-0.025 c 0,0 -1.0163,-0.1751 -1.0042,-1.3091 0.012,-1.134 0.86,-1.4934 0.86,-1.4934 z"
-       id="path475"
-       sodipodi:nodetypes="cccccccczc" />
-    <g
-       stroke-width="1.98819"
-       id="g12"
-       transform="matrix(1.0048041,0,0,1,-29.5372,0.96769746)">
-      <g
-         id="g6109">
-        <path
-           d="m 6154.9125,1461.4023 v -1.5416 h -10.2281 c 0,0 -1.6355,-0.2887 -1.6506,-2.0554 -0.015,-1.7667 1.1392,-2.5693 1.1392,-2.5693 l -1.0228,-1.0278 c 0,0 -1.5249,0.4715 -1.5129,3.5971 0.012,3.1256 3.0471,3.597 3.0471,3.597 z"
-           font-variant-ligatures="normal"
-           font-variant-position="normal"
-           font-variant-caps="normal"
-           font-variant-numeric="normal"
-           font-variant-alternates="normal"
-           font-feature-settings="normal"
-           text-indent="0"
-           text-align="start"
-           text-decoration-line="none"
-           text-decoration-style="solid"
-           text-decoration-color="#000000"
-           text-transform="none"
-           text-orientation="mixed"
-           shape-padding="0"
-           isolation="auto"
-           mix-blend-mode="normal"
-           id="path8"
-           sodipodi:nodetypes="ccczcczcc" />
-        <path
-           d="m 6152.1159,1463.9604 -0.011,-0.6055 c 0,-0.2486 0.1258,-0.5117 0.3028,-0.6954 l 1.8753,-2.0367 -1.8389,-2.0064 c -0.1761,-0.1838 -0.2913,-0.4471 -0.3028,-0.6965 l -0.03,-0.6439 h 0.4297 c 0.2998,9e-4 0.534,0.087 0.7255,0.2728 l 2.6688,3.0745 -2.8125,3.0778 c -0.1916,0.1838 -0.4257,0.2708 -0.7255,0.2708 z"
-           text-indent="0"
-           text-align="start"
-           text-decoration-line="none"
-           text-transform="none"
-           id="path10"
-           sodipodi:nodetypes="cscccscsccccc"
-           style="stroke-width:1.98822" />
-      </g>
-    </g>
+       d="m 4.9880578,2.0000943 c 0,0 -0.707031,-0.015625 -1.449219,0.355469 -0.738281,0.371093 -1.550781,1.3125 -1.550781,2.644531 L 2,8 0,8.008 v 1.0000532 h 0.0078125 c -0.00390625,0.265625 0.1015625,0.519531 0.2851565,0.707031 l 2,1.9999998 c 0.390625,0.390625 1.023437,0.390625 1.414062,0 l 2,-1.9999998 c 0.183594,-0.1875 0.289063,-0.441406 0.289063,-0.707031 H 6 V 8 H 4 V 4.8853291 C 4.105469,4.0845481 4.4880578,4.0000943 4.9880578,4.0000943 h 5 c 0.5507812,0 1.0000002,-0.449219 1.0000002,-1 0,-0.550781 -0.449219,-1 -1.0000002,-1 z"
+       id="path730"
+       sodipodi:nodetypes="ccscccccssccccccssssc" />
     <use
        x="0"
        y="0"
-       xlink:href="#g12"
-       id="use6156"
-       transform="rotate(180,6149.8137,1457.7369)" />
+       xlink:href="#path730"
+       id="use886"
+       transform="rotate(180,8.0000289,8.0040264)" />
+    <path
+       style="fill:#2e3436;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 5,6.9996297 7,7 V 8.1 H 9 V 6.25 C 9,6.0044903 9.0007287,6.0100971 9.1750392,5.8249608 L 9.75,5.25 C 9.8994961,5.0729782 9.8896552,5.0015656 9.75,5 H 5.25 C 5.1033608,4.9948363 4.9962233,5.082968 5,5.25 Z"
+       id="path1120"
+       sodipodi:nodetypes="ccccccccccc" />
     <use
        x="0"
        y="0"
-       xlink:href="#path475"
-       id="use6158"
-       transform="rotate(180,6149.8056,1457.7452)" />
+       xlink:href="#path1120"
+       id="use1676"
+       transform="rotate(180,7.9992316,8)" />
   </g>
 </svg>

--- a/data/icons/scalable/actions/reposted-symbolic.svg
+++ b/data/icons/scalable/actions/reposted-symbolic.svg
@@ -3,7 +3,7 @@
    height="16px"
    viewBox="0 0 16 16"
    width="16px"
-   sodipodi:docname="repost-symbolic.svg"
+   sodipodi:docname="reposted-symbolic.svg"
    inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
    version="1.1"
    id="svg16"
@@ -22,14 +22,14 @@
      inkscape:pagecheckerboard="1"
      showgrid="false"
      inkscape:zoom="141.77491"
-     inkscape:cx="2.380534"
-     inkscape:cy="6.1893884"
+     inkscape:cx="0.92752659"
+     inkscape:cy="8.0091744"
      inkscape:window-width="2560"
      inkscape:window-height="1372"
      inkscape:window-x="0"
      inkscape:window-y="32"
      inkscape:window-maximized="1"
-     inkscape:current-layer="g12"
+     inkscape:current-layer="g14"
      id="namedview2"
      inkscape:showpageshadow="2"
      inkscape:deskcolor="#d1d1d1" />
@@ -38,6 +38,11 @@
      stroke-width="2.05545"
      transform="matrix(0.97302294 0 0 0.97302255 -5975.9018 -1410.419)"
      id="g14">
+    <path
+       style="fill:#4d4d4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.02773px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 6144.7824,1456.411 2.3339,2.2727 2.181,0.013 -0.01,-1.9037 -1.012,-1.074 6.3024,-0 c 1.1321,0.6681 1.3394,1.606 -0.031,2.45 l -2.1993,-2.1847 -2.0641,-0 0.01,1.9069 0.9775,1.0529 -6.1218,-0.016 c -1.5404,-0.7325 -1.1337,-1.5801 -0.5627,-2.3655 z"
+       id="path475"
+       sodipodi:nodetypes="cccccccccccccc" />
     <path
        d="m 6146.3151,1453.4317 v 1.9346 h 8.3267 c 0.8126,0 1.451,0.6384 1.451,1.4509 0,0.8125 -0.2583,1.0269 -0.8995,1.4724 l -0.3375,0.2346 1.3669,1.3599 0.3723,-0.262 c 0.4634,-0.3262 1.4323,-0.9468 1.4323,-2.8049 0,-1.8581 -1.5273,-3.3855 -3.3855,-3.3855 z"
        stroke-width="1.98818"
@@ -70,9 +75,9 @@
     <g
        stroke-width="1.98819"
        id="g12"
-       transform="translate(0,5.3513327e-4)">
+       transform="translate(-2.8807212e-5,4.7729717e-4)">
       <path
-         d="m 6153.4323,1461.2013 v -1.9346 h -8.4631 c -0.8126,0 -1.451,-0.6384 -1.451,-1.4509 0,-0.8125 0.3942,-1.2086 0.5985,-1.3498 l 0.4383,-0.3028 -1.2955,-1.3913 -0.2842,0.2117 c -0.4363,0.325 -1.3916,0.9741 -1.3916,2.8322 0,1.8581 1.5273,3.3855 3.3855,3.3855 z"
+         d="m 6153.4323,1461.2013 v -1.9346 h -8.4631 c -0.8126,0 -1.451,-0.6384 -1.451,-1.4509 0,-0.8125 0.4794,-1.2675 0.5985,-1.3498 l 0.4383,-0.3028 -1.2955,-1.3913 -0.2842,0.2117 c -0.4363,0.325 -1.3916,0.9741 -1.3916,2.8322 0,1.8581 1.5273,3.3855 3.3855,3.3855 z"
          font-variant-ligatures="normal"
          font-variant-position="normal"
          font-variant-caps="normal"

--- a/data/icons/scalable/actions/reposted-symbolic.svg
+++ b/data/icons/scalable/actions/reposted-symbolic.svg
@@ -7,6 +7,9 @@
    inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
    version="1.1"
    id="svg16"
+   inkscape:export-filename="reposted-symbolic.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -21,10 +24,10 @@
      inkscape:pageshadow="0"
      inkscape:pageopacity="0"
      inkscape:pagecheckerboard="1"
-     showgrid="false"
-     inkscape:zoom="35.443728"
-     inkscape:cx="23.544363"
-     inkscape:cy="18.691601"
+     showgrid="true"
+     inkscape:zoom="128"
+     inkscape:cx="7.3476562"
+     inkscape:cy="6.8476562"
      inkscape:window-width="2560"
      inkscape:window-height="1372"
      inkscape:window-x="0"
@@ -33,7 +36,18 @@
      inkscape:current-layer="g14"
      id="namedview2"
      inkscape:showpageshadow="2"
-     inkscape:deskcolor="#d1d1d1" />
+     inkscape:deskcolor="#d1d1d1"
+     showguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid794"
+       dotted="true"
+       spacingx="1"
+       spacingy="1"
+       empspacing="4"
+       originx="0"
+       originy="0" />
+  </sodipodi:namedview>
   <g
      fill="#474747"
      stroke-width="2.05545"
@@ -41,17 +55,17 @@
      id="g14">
     <path
        style="fill:#4d4d4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.02773px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 6144.7824,1456.4182 1.6775,1.7667 1.6643,0.011 0.033,-2.0523 -0.5371,-0.6373 2.1924,0.01 -0.015,4.1509 -4.9182,-0.01 c 0,0 -1.0325,-0.2139 -1.0156,-1.5185 0.017,-1.3046 0.9187,-1.7205 0.9187,-1.7205 z"
+       d="m 6144.8107,1456.9734 1.295,1.2857 h 2.672 v -1.5416 l -0.5138,-1.0142 1.6443,-0.013 v 4.1109 l -4.9533,-0.025 c 0,0 -1.0163,-0.1751 -1.0042,-1.3091 0.012,-1.134 0.86,-1.4934 0.86,-1.4934 z"
        id="path475"
        sodipodi:nodetypes="cccccccczc" />
     <g
        stroke-width="1.98819"
        id="g12"
-       transform="translate(-2.8807212e-5,0.78336847)">
+       transform="matrix(1.0048041,0,0,1,-29.5372,0.96769746)">
       <g
          id="g6109">
         <path
-           d="m 6154.6518,1461.2307 -0.028,-1.573 -9.9622,-0.027 c -2.135,-0.6239 -1.8071,-3.6229 -0.4561,-4.5383 l -0.8575,-0.9532 c -3.1875,2.1382 -1.532,7.0767 1.621,7.0618 z"
+           d="m 6154.9125,1461.4023 v -1.5416 h -10.2281 c 0,0 -1.6355,-0.2887 -1.6506,-2.0554 -0.015,-1.7667 1.1392,-2.5693 1.1392,-2.5693 l -1.0228,-1.0278 c 0,0 -1.5249,0.4715 -1.5129,3.5971 0.012,3.1256 3.0471,3.597 3.0471,3.597 z"
            font-variant-ligatures="normal"
            font-variant-position="normal"
            font-variant-caps="normal"
@@ -69,15 +83,16 @@
            isolation="auto"
            mix-blend-mode="normal"
            id="path8"
-           sodipodi:nodetypes="ccccccc" />
+           sodipodi:nodetypes="ccczcczcc" />
         <path
-           d="m 6152.1287,1463.7835 -0.011,-0.6055 c 0,-0.2486 0.1258,-0.5117 0.3028,-0.6954 l 1.8752,-2.0367 -1.8388,-2.0064 c -0.1761,-0.1838 -0.2913,-0.4471 -0.3028,-0.6965 l -0.03,-0.6439 h 0.4297 c 0.2998,9e-4 0.5339,0.087 0.7254,0.2728 l 2.6688,3.0745 -2.8125,3.0778 c -0.1915,0.1838 -0.4256,0.2708 -0.7254,0.2708 z"
+           d="m 6152.1159,1463.9604 -0.011,-0.6055 c 0,-0.2486 0.1258,-0.5117 0.3028,-0.6954 l 1.8753,-2.0367 -1.8389,-2.0064 c -0.1761,-0.1838 -0.2913,-0.4471 -0.3028,-0.6965 l -0.03,-0.6439 h 0.4297 c 0.2998,9e-4 0.534,0.087 0.7255,0.2728 l 2.6688,3.0745 -2.8125,3.0778 c -0.1916,0.1838 -0.4257,0.2708 -0.7255,0.2708 z"
            text-indent="0"
            text-align="start"
            text-decoration-line="none"
            text-transform="none"
            id="path10"
-           sodipodi:nodetypes="cscccscsccccc" />
+           sodipodi:nodetypes="cscccscsccccc"
+           style="stroke-width:1.98822" />
       </g>
     </g>
     <use
@@ -85,12 +100,12 @@
        y="0"
        xlink:href="#g12"
        id="use6156"
-       transform="rotate(180,6149.8102,1457.6325)" />
+       transform="rotate(180,6149.8137,1457.7369)" />
     <use
        x="0"
        y="0"
        xlink:href="#path475"
        id="use6158"
-       transform="rotate(180,6149.7549,1457.591)" />
+       transform="rotate(180,6149.8056,1457.7452)" />
   </g>
 </svg>

--- a/lib/Base/Content/Post.vala
+++ b/lib/Base/Content/Post.vala
@@ -20,6 +20,14 @@
 
 using GLib;
 
+public struct Backend.PostInteractionData {
+  int liked_count;
+  int replied_count;
+  int reposted_count;
+  bool is_favourited;
+  bool is_reposted;
+}
+
 /**
  * Represents one posted status message.
  */
@@ -76,17 +84,17 @@ public abstract class Backend.Post : Object {
   /**
    * How often the post was liked.
    */
-  public int liked_count { get; construct; }
+  public int liked_count { get; protected construct set; }
 
   /**
    * How often the post was replied to.
    */
-  public int replied_count { get; construct; }
+  public int replied_count { get; protected construct set; }
 
   /**
    * How often this post was reposted or quoted.
    */
-  public int reposted_count { get; construct; }
+  public int reposted_count { get; protected construct set; }
 
   /**
    * The id for the post this post replies to.
@@ -96,13 +104,13 @@ public abstract class Backend.Post : Object {
   /**
    * Whether the post has been favourited by the session user
    */
-  public bool is_favourited { get; construct; default = false; }
+  public bool is_favourited { get; protected construct set; default = false; }
 
 
   /**
    * Whether the post has been reblogged by the session user
    */
-   public bool is_reposted { get; construct; default = false; }
+   public bool is_reposted { get; protected construct set; default = false; }
 
   /**
    * Emitted when data in this post has changed.
@@ -119,6 +127,70 @@ public abstract class Backend.Post : Object {
       post_updated ();
     });
   }
+
+    /**
+   * Favourite/like this post.
+   *
+   * Adds the favourite/like/platform-equivalent flag to the post. If the post
+   * is already favourited/liked then this is a noop and no exception will be thrown.
+   *
+   * @throws Error Any errors while favouriting, such as unauthorised actions, missing posts, or network issues
+   */
+  public async void favourite () throws Error {
+    yield this.session.favourite_post (this);
+  }
+
+  /**
+   * Unfavourite/unlike this post.
+   *
+   * Removes the favourite/like/platform-equivalent flag from the post. If the post
+   * is not favourited/liked then this is a noop and no exception will be thrown.
+   *
+   * @throws Error Any errors while unfavouriting, such as unauthorised actions, missing posts, or network issues
+   */
+   public async void unfavourite () throws Error {
+    yield this.session.unfavourite_post (this);
+   }
+
+  /**
+   * Reblogs/boosts/retweets this post.
+   *
+   * Reblogs the post to the user's timeline. If the post is already reblogged then this is a noop
+   * and no exception will be thrown.
+   *
+   * @return A Post object representing the reposted post in the user's timeline
+   *
+   * @throws Error Any errors while reblogging, such as unauthorised actions, missing posts, or network issues
+   */
+   public async Backend.Post reblog () throws Error {
+    return yield this.session.reblog_post (this);
+   }
+
+  /**
+   * Un-reblogs/unboosts/un-retweets this post.
+   *
+   * Removes the reblog from the user's timeline. If the post is not reblogged then this is a noop
+   * and no exception will be thrown.
+   *
+   * @throws Error Any errors while un-reblogging, such as unauthorised actions, missing posts, or network issues
+   */
+   public async void unreblog () throws Error {
+    yield this.session.unreblog_post (this);
+   }
+
+   /*
+    * Updates interaction data that may change over time
+    *
+    * @param A struct holding the new interaction data
+    */
+   public void update_interactions (PostInteractionData data) {
+    this.liked_count = data.liked_count;
+    this.replied_count = data.replied_count;
+    this.reposted_count = data.reposted_count;
+    this.is_favourited = data.is_favourited;
+    this.is_reposted = data.is_reposted;
+    post_updated();
+   }
 
   /**
    * Returns a possible post that this post referenced.

--- a/lib/Base/Content/Post.vala
+++ b/lib/Base/Content/Post.vala
@@ -94,6 +94,17 @@ public abstract class Backend.Post : Object {
   public string? replied_to_id { get; construct; }
 
   /**
+   * Whether the post has been favourited by the session user
+   */
+  public bool is_favourited { get; construct; default = false; }
+
+
+  /**
+   * Whether the post has been reblogged by the session user
+   */
+   public bool is_reposted { get; construct; default = false; }
+
+  /**
    * Emitted when data in this post has changed.
    */
   public signal void post_updated ();

--- a/lib/Base/Content/Post.vala
+++ b/lib/Base/Content/Post.vala
@@ -134,10 +134,11 @@ public abstract class Backend.Post : Object {
    * Adds the favourite/like/platform-equivalent flag to the post. If the post
    * is already favourited/liked then this is a noop and no exception will be thrown.
    *
+   * @returns This post object, which may have been updated if the platform supports it
    * @throws Error Any errors while favouriting, such as unauthorised actions, missing posts, or network issues
    */
-  public async void favourite () throws Error {
-    yield this.session.favourite_post (this);
+  public async Backend.Post favourite () throws Error {
+    return yield this.session.favourite_post (this);
   }
 
   /**
@@ -146,10 +147,11 @@ public abstract class Backend.Post : Object {
    * Removes the favourite/like/platform-equivalent flag from the post. If the post
    * is not favourited/liked then this is a noop and no exception will be thrown.
    *
+   * @returns This post object, which may have been updated if the platform supports it
    * @throws Error Any errors while unfavouriting, such as unauthorised actions, missing posts, or network issues
    */
-   public async void unfavourite () throws Error {
-    yield this.session.unfavourite_post (this);
+   public async Backend.Post unfavourite () throws Error {
+    return yield this.session.unfavourite_post (this);
    }
 
   /**
@@ -158,11 +160,11 @@ public abstract class Backend.Post : Object {
    * Reblogs the post to the user's timeline. If the post is already reblogged then this is a noop
    * and no exception will be thrown.
    *
-   * @return A Post object representing the reposted post in the user's timeline
+   * @return A Post object representing the reposted post in the user's timeline (if provided by the platform)
    *
    * @throws Error Any errors while reblogging, such as unauthorised actions, missing posts, or network issues
    */
-   public async Backend.Post reblog () throws Error {
+   public async Backend.Post? reblog () throws Error {
     return yield this.session.reblog_post (this);
    }
 
@@ -172,10 +174,11 @@ public abstract class Backend.Post : Object {
    * Removes the reblog from the user's timeline. If the post is not reblogged then this is a noop
    * and no exception will be thrown.
    *
+   * @returns the unreblogged post (if available)
    * @throws Error Any errors while un-reblogging, such as unauthorised actions, missing posts, or network issues
    */
-   public async void unreblog () throws Error {
-    yield this.session.unreblog_post (this);
+   public async Backend.Post? unreblog () throws Error {
+    return yield this.session.unreblog_post (this);
    }
 
    /*

--- a/lib/Base/System/Session.vala
+++ b/lib/Base/System/Session.vala
@@ -109,7 +109,7 @@ public abstract class Backend.Session : Object {
    *
    * @return The post created from the data.
    */
-  internal abstract Post load_post (Json.Object data);
+  internal abstract Post load_post (Json.Object data, bool force_load = false);
 
   /**
    * Loads a list of downloaded posts.

--- a/lib/Base/System/Session.vala
+++ b/lib/Base/System/Session.vala
@@ -124,6 +124,54 @@ public abstract class Backend.Session : Object {
   internal abstract Post[] load_post_list (Json.Node json);
 
   /**
+   * Favourites/likes a post.
+   *
+   * Adds the favourite/like/platform-equivalent flag to a post. If the post
+   * is already favourited/liked then this is a noop and no exception will be thrown.
+   *
+   * @param post The post to favourite
+   *
+   * @throws Error Any errors while favouriting, such as unauthorised actions, missing posts, or network issues
+   */
+  internal abstract async Backend.Post favourite_post (Backend.Post post) throws Error;
+
+  /**
+   * Unfavourites/unlikes a post.
+   *
+   * Removes the favourite/like/platform-equivalent flag from a post. If the post
+   * is not favourited/liked then this is a noop and no exception will be thrown.
+   *
+   * @param post The post to unfavourite
+   *
+   * @throws Error Any errors while unfavouriting, such as unauthorised actions, missing posts, or network issues
+   */
+  internal abstract async Backend.Post unfavourite_post (Backend.Post post) throws Error;
+
+  /**
+   * Reblogs/boosts/retweets a post.
+   *
+   * Reblogs a post to the user's timeline. If the post is already reblogged then this is a noop
+   * and no exception will be thrown.
+   *
+   * @param post The post to reblog
+   *
+   * @throws Error Any errors while reblogging, such as unauthorised actions, missing posts, or network issues
+   */
+  internal abstract async Backend.Post reblog_post (Backend.Post post) throws Error;
+
+  /**
+   * Un-reblogs/unboosts/un-retweets a post.
+   *
+   * Removes a reblog from the user's timeline. If the post is not reblogged then this is a noop
+   * and no exception will be thrown.
+   *
+   * @param post The post to un-reblog
+   *
+   * @throws Error Any errors while un-reblogging, such as unauthorised actions, missing posts, or network issues
+   */
+  internal abstract async Backend.Post unreblog_post (Backend.Post post) throws Error;
+
+  /**
    * Retrieves an user for an specified id.
    *
    * If the user was already pulled and is present in memory, the version

--- a/lib/Base/System/Session.vala
+++ b/lib/Base/System/Session.vala
@@ -133,7 +133,7 @@ public abstract class Backend.Session : Object {
    *
    * @throws Error Any errors while favouriting, such as unauthorised actions, missing posts, or network issues
    */
-  internal abstract async Backend.Post favourite_post (Backend.Post post) throws Error;
+  public abstract async Backend.Post favourite_post (Backend.Post post) throws Error;
 
   /**
    * Unfavourites/unlikes a post.
@@ -145,7 +145,7 @@ public abstract class Backend.Session : Object {
    *
    * @throws Error Any errors while unfavouriting, such as unauthorised actions, missing posts, or network issues
    */
-  internal abstract async Backend.Post unfavourite_post (Backend.Post post) throws Error;
+   public abstract async Backend.Post unfavourite_post (Backend.Post post) throws Error;
 
   /**
    * Reblogs/boosts/retweets a post.
@@ -157,7 +157,7 @@ public abstract class Backend.Session : Object {
    *
    * @throws Error Any errors while reblogging, such as unauthorised actions, missing posts, or network issues
    */
-  internal abstract async Backend.Post reblog_post (Backend.Post post) throws Error;
+   public abstract async Backend.Post reblog_post (Backend.Post post) throws Error;
 
   /**
    * Un-reblogs/unboosts/un-retweets a post.
@@ -169,7 +169,7 @@ public abstract class Backend.Session : Object {
    *
    * @throws Error Any errors while un-reblogging, such as unauthorised actions, missing posts, or network issues
    */
-  internal abstract async Backend.Post unreblog_post (Backend.Post post) throws Error;
+   public abstract async Backend.Post unreblog_post (Backend.Post post) throws Error;
 
   /**
    * Retrieves an user for an specified id.

--- a/lib/Base/System/Session.vala
+++ b/lib/Base/System/Session.vala
@@ -109,7 +109,7 @@ public abstract class Backend.Session : Object {
    *
    * @return The post created from the data.
    */
-  internal abstract Post load_post (Json.Object data, bool force_load = false);
+  internal abstract Post load_post (Json.Object data);
 
   /**
    * Loads a list of downloaded posts.

--- a/lib/Mastodon/Content/Post.vala
+++ b/lib/Mastodon/Content/Post.vala
@@ -71,7 +71,10 @@ public class Backend.Mastodon.Post : Backend.Post {
       // Set replied_to_id
       replied_to_id: ! json.get_null_member ("in_reply_to_id")
                        ? json.get_string_member ("in_reply_to_id")
-                       : null
+                       : null,
+
+      is_favourited: json.get_boolean_member_with_default ("favourited", false),
+      is_reposted: json.get_boolean_member_with_default ("reblogged", false)
     );
 
     // Parse the text into modules

--- a/lib/Mastodon/Content/Post.vala
+++ b/lib/Mastodon/Content/Post.vala
@@ -85,17 +85,9 @@ public class Backend.Mastodon.Post : Backend.Post {
     text = Backend.Utils.TextUtils.format_text (text_modules);
 
     // Set the referenced post
-    if (! json.get_null_member ("reblog")) {
-      referenced_post = session.load_post (json.get_object_member ("reblog"));
-      // Bubble changes to the "is reposted" state of the referenced post through to this post.
-      // This handles the situation where the user reblogs a reblog, which then loads a response
-      // with the original post in but not this post.
-      // FIXME: Doesn't seem to be triggering correctly
-      referenced_post.bind_property ("is-reposted", this, "is-reposted", GLib.BindingFlags.SYNC_CREATE);
-    }
-    else {
-      referenced_post = null;
-    }
+    referenced_post = ! json.get_null_member ("reblog")
+                        ? session.load_post (json.get_object_member ("reblog"))
+                        : null;
 
     // Get media attachments
     Backend.Media[] parsed_media = {};

--- a/lib/Mastodon/Content/Post.vala
+++ b/lib/Mastodon/Content/Post.vala
@@ -37,6 +37,7 @@ public class Backend.Mastodon.Post : Backend.Post {
                         ? json.get_string_member ("url")
                         : json.get_string_member ("uri");
     string post_domain = Utils.ParseUtils.strip_domain (post_url);
+    var interaction_data = get_interaction_data (json);
 
     // Construct object with properties
     Object (
@@ -61,9 +62,9 @@ public class Backend.Mastodon.Post : Backend.Post {
       domain: post_domain,
 
       // Set metrics
-      liked_count:    (int) json.get_int_member ("favourites_count"),
-      replied_count:  (int) json.get_int_member ("replies_count"),
-      reposted_count: (int) json.get_int_member ("reblogs_count"),
+      liked_count:    interaction_data.liked_count,
+      replied_count:  interaction_data.replied_count,
+      reposted_count: interaction_data.reposted_count,
 
       // Set the author
       author: session.load_user (json.get_object_member ("account")),
@@ -73,8 +74,8 @@ public class Backend.Mastodon.Post : Backend.Post {
                        ? json.get_string_member ("in_reply_to_id")
                        : null,
 
-      is_favourited: json.get_boolean_member_with_default ("favourited", false),
-      is_reposted: json.get_boolean_member_with_default ("reblogged", false)
+      is_favourited: interaction_data.is_favourited,
+      is_reposted: interaction_data.is_reposted
     );
 
     // Parse the text into modules
@@ -118,5 +119,16 @@ public class Backend.Mastodon.Post : Backend.Post {
    * Stores the referenced post.
    */
   private Backend.Post? referenced_post;
+
+  public static Backend.PostInteractionData get_interaction_data (Json.Object json) {
+    return Backend.PostInteractionData() {
+      liked_count =    (int) json.get_int_member ("favourites_count"),
+      replied_count =  (int) json.get_int_member ("replies_count"),
+      reposted_count = (int) json.get_int_member ("reblogs_count"),
+
+      is_favourited = json.get_boolean_member_with_default ("favourited", false),
+      is_reposted = json.get_boolean_member_with_default ("reblogged", false)
+    };
+  }
 
 }

--- a/lib/Mastodon/Content/Post.vala
+++ b/lib/Mastodon/Content/Post.vala
@@ -85,9 +85,17 @@ public class Backend.Mastodon.Post : Backend.Post {
     text = Backend.Utils.TextUtils.format_text (text_modules);
 
     // Set the referenced post
-    referenced_post = ! json.get_null_member ("reblog")
-                        ? session.load_post (json.get_object_member ("reblog"))
-                        : null;
+    if (! json.get_null_member ("reblog")) {
+      referenced_post = session.load_post (json.get_object_member ("reblog"));
+      // Bubble changes to the "is reposted" state of the referenced post through to this post.
+      // This handles the situation where the user reblogs a reblog, which then loads a response
+      // with the original post in but not this post.
+      // FIXME: Doesn't seem to be triggering correctly
+      referenced_post.bind_property ("is-reposted", this, "is-reposted", GLib.BindingFlags.SYNC_CREATE);
+    }
+    else {
+      referenced_post = null;
+    }
 
     // Get media attachments
     Backend.Media[] parsed_media = {};

--- a/lib/Mastodon/System/SessionCalls.vala
+++ b/lib/Mastodon/System/SessionCalls.vala
@@ -99,6 +99,50 @@ public partial class Backend.Mastodon.Session : Backend.Session {
     return post_list;
   }
 
+  internal override async Backend.Post favourite_post (Backend.Post post) throws Error {
+    // Create the proxy call
+    Rest.ProxyCall call = proxy.new_call ();
+    call.set_method ("POST");
+    call.set_function (@"api/v1/statuses/$(post.id)/favourite");
+
+    // Send the message and return the updated post
+    Json.Node json = yield server.call (call);
+    return load_post (json.get_object ());
+  }
+
+  internal override async Backend.Post unfavourite_post (Backend.Post post) throws Error {
+    // Create the proxy call
+    Rest.ProxyCall call = proxy.new_call ();
+    call.set_method ("POST");
+    call.set_function (@"api/v1/statuses/$(post.id)/unfavourite");
+
+    // Send the message and return the updated post
+    Json.Node json = yield server.call (call);
+    return load_post (json.get_object ());
+  }
+
+  internal override async Backend.Post reblog_post (Backend.Post post) throws Error {
+    // Create the proxy call
+    Rest.ProxyCall call = proxy.new_call ();
+    call.set_method ("POST");
+    call.set_function (@"api/v1/statuses/$(post.id)/reblog");
+
+    // Send the message and return the updated post
+    Json.Node json = yield server.call (call);
+    return load_post (json.get_object ());
+  }
+
+  internal override async Backend.Post unreblog_post (Backend.Post post) throws Error {
+    // Create the proxy call
+    Rest.ProxyCall call = proxy.new_call ();
+    call.set_method ("POST");
+    call.set_function (@"api/v1/statuses/$(post.id)/unreblog");
+
+    // Send the message and return the updated post
+    Json.Node json = yield server.call (call);
+    return load_post (json.get_object ());
+  }
+
   /**
    * Retrieves an user for an specified id.
    *

--- a/lib/Mastodon/System/SessionCalls.vala
+++ b/lib/Mastodon/System/SessionCalls.vala
@@ -61,12 +61,12 @@ public partial class Backend.Mastodon.Session : Backend.Session {
    * This is an platform-specific implementation of the abstract method
    * defined in the base class, for more details see the base method.
    */
-  internal override Backend.Post load_post (Json.Object data) {
+  internal override Backend.Post load_post (Json.Object data, bool force_load = false) {
     // Get the id of the post
     string id = data.get_string_member ("id");
 
     // Check if the post is already present in memory
-    if (pulled_posts.contains (id)) {
+    if (pulled_posts.contains (id) && ! force_load) {
       return pulled_posts [id];
     }
 
@@ -107,7 +107,7 @@ public partial class Backend.Mastodon.Session : Backend.Session {
 
     // Send the message and return the updated post
     Json.Node json = yield server.call (call);
-    return load_post (json.get_object ());
+    return load_post (json.get_object (), true);
   }
 
   public override async Backend.Post unfavourite_post (Backend.Post post) throws Error {
@@ -118,7 +118,7 @@ public partial class Backend.Mastodon.Session : Backend.Session {
 
     // Send the message and return the updated post
     Json.Node json = yield server.call (call);
-    return load_post (json.get_object ());
+    return load_post (json.get_object (), true);
   }
 
   public override async Backend.Post reblog_post (Backend.Post post) throws Error {
@@ -129,7 +129,7 @@ public partial class Backend.Mastodon.Session : Backend.Session {
 
     // Send the message and return the updated post
     Json.Node json = yield server.call (call);
-    return load_post (json.get_object ());
+    return load_post (json.get_object (), true);
   }
 
   public override async Backend.Post unreblog_post (Backend.Post post) throws Error {
@@ -140,7 +140,7 @@ public partial class Backend.Mastodon.Session : Backend.Session {
 
     // Send the message and return the updated post
     Json.Node json = yield server.call (call);
-    return load_post (json.get_object ());
+    return load_post (json.get_object (), true);
   }
 
   /**

--- a/lib/Mastodon/System/SessionCalls.vala
+++ b/lib/Mastodon/System/SessionCalls.vala
@@ -132,7 +132,7 @@ public partial class Backend.Mastodon.Session : Backend.Session {
     call.set_method ("POST");
     call.set_function (@"api/v1/statuses/$(post.id)/reblog");
 
-    // Send the message and return the updated post
+    // Send the message and return the reblog post
     Json.Node json = yield server.call (call);
     return load_post (json.get_object ());
   }
@@ -143,7 +143,7 @@ public partial class Backend.Mastodon.Session : Backend.Session {
     call.set_method ("POST");
     call.set_function (@"api/v1/statuses/$(post.id)/unreblog");
 
-    // Send the message and return the updated post
+    // Send the message and return the unreblogged post
     Json.Node json = yield server.call (call);
     return load_post (json.get_object ());
   }

--- a/lib/Mastodon/System/SessionCalls.vala
+++ b/lib/Mastodon/System/SessionCalls.vala
@@ -99,7 +99,7 @@ public partial class Backend.Mastodon.Session : Backend.Session {
     return post_list;
   }
 
-  internal override async Backend.Post favourite_post (Backend.Post post) throws Error {
+  public override async Backend.Post favourite_post (Backend.Post post) throws Error {
     // Create the proxy call
     Rest.ProxyCall call = proxy.new_call ();
     call.set_method ("POST");
@@ -110,7 +110,7 @@ public partial class Backend.Mastodon.Session : Backend.Session {
     return load_post (json.get_object ());
   }
 
-  internal override async Backend.Post unfavourite_post (Backend.Post post) throws Error {
+  public override async Backend.Post unfavourite_post (Backend.Post post) throws Error {
     // Create the proxy call
     Rest.ProxyCall call = proxy.new_call ();
     call.set_method ("POST");
@@ -121,7 +121,7 @@ public partial class Backend.Mastodon.Session : Backend.Session {
     return load_post (json.get_object ());
   }
 
-  internal override async Backend.Post reblog_post (Backend.Post post) throws Error {
+  public override async Backend.Post reblog_post (Backend.Post post) throws Error {
     // Create the proxy call
     Rest.ProxyCall call = proxy.new_call ();
     call.set_method ("POST");
@@ -132,7 +132,7 @@ public partial class Backend.Mastodon.Session : Backend.Session {
     return load_post (json.get_object ());
   }
 
-  internal override async Backend.Post unreblog_post (Backend.Post post) throws Error {
+  public override async Backend.Post unreblog_post (Backend.Post post) throws Error {
     // Create the proxy call
     Rest.ProxyCall call = proxy.new_call ();
     call.set_method ("POST");

--- a/lib/Mastodon/System/SessionCalls.vala
+++ b/lib/Mastodon/System/SessionCalls.vala
@@ -61,18 +61,23 @@ public partial class Backend.Mastodon.Session : Backend.Session {
    * This is an platform-specific implementation of the abstract method
    * defined in the base class, for more details see the base method.
    */
-  internal override Backend.Post load_post (Json.Object data, bool force_load = false) {
+  internal override Backend.Post load_post (Json.Object data) {
     // Get the id of the post
     string id = data.get_string_member ("id");
 
+    Post post;
+
     // Check if the post is already present in memory
-    if (pulled_posts.contains (id) && ! force_load) {
-      return pulled_posts [id];
+    if (pulled_posts.contains (id)) {
+      post = pulled_posts [id];
+      post.update_interactions (Backend.Mastodon.Post.get_interaction_data(data));
+    }
+    else {
+      // Create a new post and add it to memory
+      post = new Post (this, data);
+      pulled_posts [id] = post;
     }
 
-    // Create a new post and add it to memory
-    Post post = new Post (this, data);
-    pulled_posts [id] = post;
     return post;
   }
 
@@ -107,7 +112,7 @@ public partial class Backend.Mastodon.Session : Backend.Session {
 
     // Send the message and return the updated post
     Json.Node json = yield server.call (call);
-    return load_post (json.get_object (), true);
+    return load_post (json.get_object ());
   }
 
   public override async Backend.Post unfavourite_post (Backend.Post post) throws Error {
@@ -118,7 +123,7 @@ public partial class Backend.Mastodon.Session : Backend.Session {
 
     // Send the message and return the updated post
     Json.Node json = yield server.call (call);
-    return load_post (json.get_object (), true);
+    return load_post (json.get_object ());
   }
 
   public override async Backend.Post reblog_post (Backend.Post post) throws Error {
@@ -129,7 +134,7 @@ public partial class Backend.Mastodon.Session : Backend.Session {
 
     // Send the message and return the updated post
     Json.Node json = yield server.call (call);
-    return load_post (json.get_object (), true);
+    return load_post (json.get_object ());
   }
 
   public override async Backend.Post unreblog_post (Backend.Post post) throws Error {
@@ -140,7 +145,7 @@ public partial class Backend.Mastodon.Session : Backend.Session {
 
     // Send the message and return the updated post
     Json.Node json = yield server.call (call);
-    return load_post (json.get_object (), true);
+    return load_post (json.get_object ());
   }
 
   /**

--- a/src/Content/PostActions.vala
+++ b/src/Content/PostActions.vala
@@ -62,24 +62,6 @@ public class PostActions : Gtk.Widget {
 
         debug("Likes: %d; Label: %s; Liked: %s", displayed_post.liked_count, likes_counter.label, displayed_post.is_favourited ? "yes" : "no");
 
-        if (displayed_post.is_favourited) {
-          likes_counter.icon_name = "liked-symbolic";
-          likes_button.add_css_class ("liked");
-        }
-        else {
-          likes_counter.icon_name = "not-liked-symbolic";
-          likes_button.remove_css_class ("liked");
-        }
-
-        if (displayed_post.is_reposted) {
-          reposts_counter.icon_name = "reposted-symbolic";
-          reposts_button.add_css_class ("reposted");
-        }
-        else {
-          reposts_counter.icon_name = "repost-symbolic";
-          reposts_button.remove_css_class ("reposted");
-        }
-
         string open_link_label   = _("Open on %s").printf (displayed_post.domain);
         var    post_options_menu = new Menu ();
         post_options_menu.append (open_link_label, "post.open-url");
@@ -93,13 +75,11 @@ public class PostActions : Gtk.Widget {
         replies_counter.label = "(null)";
         replies_button.sensitive = false;
 
-        likes_counter.icon_name = "not-liked-symbolic";
-        likes_button.remove_css_class ("liked");
-        reposts_counter.icon_name = "repost-symbolic";
-        reposts_button.remove_css_class ("reposted");
-
         options_button.menu_model = null;
       }
+
+      DisplayUtils.conditional_button_content (displayed_post != null && displayed_post.is_favourited, likes_counter, "liked", "liked-symbolic", "not-liked-symbolic");
+      DisplayUtils.conditional_button_content (displayed_post != null && displayed_post.is_reposted, reposts_counter, "reposted", "reposted-symbolic", "repost-symbolic");
     }
   }
 

--- a/src/Content/PostActions.vala
+++ b/src/Content/PostActions.vala
@@ -56,6 +56,9 @@ public class PostActions : Gtk.Widget {
       likes_counter.label   = displayed_post != null ? DisplayUtils.shortened_metric (displayed_post.liked_count)    : "(null)";
       reposts_counter.label = displayed_post != null ? DisplayUtils.shortened_metric (displayed_post.reposted_count) : "(null)";
       replies_counter.label = displayed_post != null ? DisplayUtils.shortened_metric (displayed_post.replied_count)  : "(null)";
+      likes_button.sensitive = displayed_post != null;
+      reposts_button.sensitive = displayed_post != null;
+      replies_button.sensitive = displayed_post != null;
 
       // Set up options menu
       if (displayed_post != null) {
@@ -80,6 +83,62 @@ public class PostActions : Gtk.Widget {
     replies_button.unparent ();
     options_button.unparent ();
     base.dispose ();
+  }
+
+  [GtkCallback]
+  private void like_post () {
+    if (!post.is_favourited) {
+      post.session.favourite_post.begin (post, (obj, res) => {
+        try {
+          var returned_post = post.session.favourite_post.end(res);
+          // Update the post in case the server is one that gives us an updated object
+          post = returned_post;
+        }
+        catch (Error e) {
+          // pass
+        }
+      });
+    }
+    else {
+      post.session.unfavourite_post.begin (post, (obj, res) => {
+        try {
+          var returned_post = post.session.favourite_post.end(res);
+          // Update the post in case the server is one that gives us an updated object
+          post = returned_post;
+        }
+        catch (Error e) {
+          // pass
+        }
+      });
+    }
+  }
+
+  [GtkCallback]
+  private void repost_post () {
+    if (!post.is_reposted) {
+      post.session.reblog_post.begin (post, (obj, res) => {
+        try {
+          var returned_post = post.session.favourite_post.end(res);
+          // Update the post in case the server is one that gives us an updated object
+          post = returned_post;
+        }
+        catch (Error e) {
+          // pass
+        }
+      });
+    }
+    else {
+      post.session.unreblog_post.begin (post, (obj, res) => {
+        try {
+          var returned_post = post.session.favourite_post.end(res);
+          // Update the post in case the server is one that gives us an updated object
+          post = returned_post;
+        }
+        catch (Error e) {
+          // pass
+        }
+      });
+    }
   }
 
   /**

--- a/src/Content/PostActions.vala
+++ b/src/Content/PostActions.vala
@@ -90,8 +90,10 @@ public class PostActions : Gtk.Widget {
     if (!post.is_favourited) {
       post.session.favourite_post.begin (post, (obj, res) => {
         try {
+          likes_button.sensitive = true;
           var returned_post = post.session.favourite_post.end(res);
           // Update the post in case the server is one that gives us an updated object
+          // FIXME: Doesn't seem to be updating!
           post = returned_post;
         }
         catch (Error e) {
@@ -102,6 +104,7 @@ public class PostActions : Gtk.Widget {
     else {
       post.session.unfavourite_post.begin (post, (obj, res) => {
         try {
+          likes_button.sensitive = true;
           var returned_post = post.session.favourite_post.end(res);
           // Update the post in case the server is one that gives us an updated object
           post = returned_post;
@@ -111,6 +114,7 @@ public class PostActions : Gtk.Widget {
         }
       });
     }
+    likes_button.sensitive = false;
   }
 
   [GtkCallback]
@@ -118,9 +122,10 @@ public class PostActions : Gtk.Widget {
     if (!post.is_reposted) {
       post.session.reblog_post.begin (post, (obj, res) => {
         try {
+          reposts_button.sensitive = true;
           var returned_post = post.session.favourite_post.end(res);
-          // Update the post in case the server is one that gives us an updated object
-          post = returned_post;
+          // TBC whether we want to do anything with this - like inject it into a stream
+          // TODO: Update counts based on the nested values
         }
         catch (Error e) {
           // pass
@@ -130,15 +135,16 @@ public class PostActions : Gtk.Widget {
     else {
       post.session.unreblog_post.begin (post, (obj, res) => {
         try {
+          reposts_button.sensitive = true;
           var returned_post = post.session.favourite_post.end(res);
-          // Update the post in case the server is one that gives us an updated object
-          post = returned_post;
+          // FIXME: How can we pass a message up that this repost should be deleted?
         }
         catch (Error e) {
           // pass
         }
       });
     }
+    reposts_button.sensitive = false;
   }
 
   /**

--- a/src/Content/PostActions.vala
+++ b/src/Content/PostActions.vala
@@ -60,8 +60,6 @@ public class PostActions : Gtk.Widget {
         replies_counter.label = DisplayUtils.shortened_metric (displayed_post.replied_count);
         replies_button.sensitive = true;
 
-        debug("Likes: %d; Label: %s; Liked: %s", displayed_post.liked_count, likes_counter.label, displayed_post.is_favourited ? "yes" : "no");
-
         string open_link_label   = _("Open on %s").printf (displayed_post.domain);
         var    post_options_menu = new Menu ();
         post_options_menu.append (open_link_label, "post.open-url");

--- a/src/Content/PostActions.vala
+++ b/src/Content/PostActions.vala
@@ -60,11 +60,11 @@ public class PostActions : Gtk.Widget {
       unbind(ref repost_count_binding);
       unbind(ref reply_count_binding);
       if (is_favourited_signal != 0) {
-        notify["is-favourited"].disconnect(set_like_counter_state);
+        displayed_post.notify["is-favourited"].disconnect(set_like_counter_state);
         is_favourited_signal = 0;
       }
       if (is_reposted_signal != 0) {
-        notify["is-reposted"].disconnect(set_repost_counter_state);
+        displayed_post.notify["is-reposted"].disconnect(set_repost_counter_state);
         is_reposted_signal = 0;
       }
 
@@ -86,8 +86,8 @@ public class PostActions : Gtk.Widget {
           targetval.set_string (DisplayUtils.shortened_metric (src));
           return true;
         });
-        is_favourited_signal = notify["is-favourited"].connect(set_like_counter_state);
-        is_favourited_signal = notify["is-reposted"].connect(set_repost_counter_state);
+        is_favourited_signal = displayed_post.notify["is-favourited"].connect(set_like_counter_state);
+        is_favourited_signal = displayed_post.notify["is-reposted"].connect(set_repost_counter_state);
 
         likes_button.sensitive = true;
         reposts_button.sensitive = true;

--- a/src/Utils/DisplayUtils.vala
+++ b/src/Utils/DisplayUtils.vala
@@ -112,6 +112,21 @@ namespace DisplayUtils {
   }
 
   /**
+   * Manages the state of a button that has an style and image state toggles
+   *
+   * @param condition If this is true, the button will use the css_class and the "on" icon, else it
+   * will not use the class and will show the "off" icon
+   * @parabuttonet The widget for which the css class should be evaluated.
+   * @param css_class The CSS-class to be added or removed
+   * @param on_icon_name The image to use for "on" icon
+   * @param off_icon_name The image to use for "on" icon
+   */
+  public void conditional_button_content (bool condition, Adw.ButtonContent button_content, string css_class, string on_icon_name, string off_icon_name) {
+    button_content.icon_name = condition ? on_icon_name : off_icon_name;
+    DisplayUtils.conditional_css (condition, button_content, css_class);
+  }
+
+  /**
    * Returns a string for a shortened version of the metric.
    *
    * @param metric The metric to be displayed.

--- a/ui/Content/PostActions.blp
+++ b/ui/Content/PostActions.blp
@@ -7,7 +7,7 @@ template PostActions : Gtk.Widget {
   };
 
   Gtk.Button likes_button {
-    sensitive: false;
+    clicked => like_post ();
 
     styles [
       "condense",
@@ -20,7 +20,7 @@ template PostActions : Gtk.Widget {
   }
 
   Gtk.Button reposts_button {
-    sensitive: false;
+    clicked => repost_post ();
 
     styles [
       "condense",

--- a/ui/style.css
+++ b/ui/style.css
@@ -295,12 +295,14 @@ UserDataDisplay.verified {
 /**
  * Colours for active action buttons
  *
- * TODO: How do we make this compatible with other themes?
+ * We use Adwaita named colours, so themes will use those colours
+ * if defined, or fall back to black and we rely on shape differences
+ * for accessibility.
  */
-button.liked buttoncontent image {
-  color: #d0324e;
+buttoncontent.liked image {
+  color: @red_4;
 }
 
-button.reposted buttoncontent image {
-  color: #0c5da3;
+buttoncontent.reposted image {
+  color: @blue_4;
 }

--- a/ui/style.css
+++ b/ui/style.css
@@ -291,3 +291,16 @@ UserDataDisplay.verified {
     opacity: 0;
   }
 }
+
+/**
+ * Colours for active action buttons
+ *
+ * TODO: How do we make this compatible with other themes?
+ */
+button.liked buttoncontent image {
+  color: #d0324e;
+}
+
+button.reposted buttoncontent image {
+  color: #0c5da3;
+}


### PR DESCRIPTION
Partially complete work on getting basic Fav/Boost working.

I don't think Mastodon allows linking to a boost, but the latest post on https://mastodon.social/@cawbird is currently a boost done from the app.

Still to do:

- [x] ~~Handle Twitter, which supplies a JSON payload and so needs a custom REST proxy class(!)~~ (Twitter now bans third-party clients)
- [x] Update favourite counts from Mastodon
- [x] Update repost count if we can on repost
- [x] ~~Work out how to delete on un-repost (and inject on repost?)~~ Doesn't appear to be a thing in Mastodon
- [x] Make it clearer when we've favourited/boosted something - maybe something [like Megalodon uses](https://github.com/CodedOre/NewCaw/discussions/62#discussioncomment-4566142) (implemented, but needs improving)