### PR TITLE
Suggestion: Top-align names

### DIFF
--- a/ui/Content/PostStatus.blp
+++ b/ui/Content/PostStatus.blp
@@ -28,26 +28,31 @@ template PostStatus : Gtk.Widget {
       size: 48;
     }
 
-    .UserButton user_button {
-      valign: center;
-      is-repost: bind PostStatus.is-repost;
-    }
+    Gtk.Box information_text_box {
+      spacing: 8;
+      valign: start;
 
-    Gtk.Label time_spacer {
-      visible: bind PostStatus.show-time;
-      label: "·";
+      .UserButton user_button {
+        valign: center;
+        is-repost: bind PostStatus.is-repost;
+      }
 
-      styles [
-        "dim-label"
-      ]
-    }
+      Gtk.Label time_spacer {
+        visible: bind PostStatus.show-time;
+        label: "·";
 
-    Gtk.Label time_label {
-      visible: bind PostStatus.show-time;
+        styles [
+          "dim-label"
+        ]
+      }
 
-      styles [
-        "dim-label"
-      ]
+      Gtk.Label time_label {
+        visible: bind PostStatus.show-time;
+
+        styles [
+          "dim-label"
+        ]
+      }
     }
   }
 }

--- a/ui/style.css
+++ b/ui/style.css
@@ -46,23 +46,15 @@ spinner.large {
  * Reduced horizontal padding on non-selected button.
  */
 button.condense {
-  transition: 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
-  padding: 4px 2px;
-}
-button.condense:hover {
-  padding: 4px 10px;
+  padding: 4px;
 }
 
 /**
  * A smaller button used inside of content.
  */
 button.inline {
-  padding: 1px 0px;
+  padding: 1px 2px;
   border-radius: 50px;
-  transition: 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
-}
-button.inline:hover {
-  padding: 1px 12px;
 }
 button.inline image {
   color: @borders;

--- a/ui/style.css
+++ b/ui/style.css
@@ -73,7 +73,7 @@ button.flat.inline {
  * more closely match "text-only" layout
  */
 button.flat.inline image{
-  margin-right:-4px
+  margin-right: -4px;
 }
 
 /**

--- a/ui/style.css
+++ b/ui/style.css
@@ -60,9 +60,20 @@ button.inline image {
   color: @borders;
 }
 
+/**
+ * Balance the rounded corners on hover with not resizing
+ * by using padding and negative margins
+ */
 button.flat.inline {
   padding: 1px 10px;
   margin: 0 -8px 0 -8px;
+}
+/**
+ * Reduce the right margin to make "button with image" layout
+ * more closely match "text-only" layout
+ */
+button.flat.inline image{
+  margin-right:-4px
 }
 
 /**

--- a/ui/style.css
+++ b/ui/style.css
@@ -46,7 +46,7 @@ spinner.large {
  * Reduced horizontal padding on non-selected button.
  */
 button.condense {
-  padding: 4px;
+  padding: 4px 6px;
 }
 
 /**
@@ -58,6 +58,11 @@ button.inline {
 }
 button.inline image {
   color: @borders;
+}
+
+button.flat.inline {
+  padding: 1px 10px;
+  margin: 0 -8px 0 -8px;
 }
 
 /**


### PR DESCRIPTION
The excess space above names next to avatars seems a bit excessive.

This PR tries to top-align the text. It also removes some resizing on hover to keep positioning consistent.

![image](https://user-images.githubusercontent.com/388582/212544739-280c4775-b5da-4992-be7b-3eef02edf0ec.png)
