### PR TITLE
Handle missing OS info

### DIFF
--- a/src/Utils/SystemInfo.vala
+++ b/src/Utils/SystemInfo.vala
@@ -128,8 +128,9 @@ namespace SystemInfo {
   private string get_system_info () {
     string info_string = "";
 
-    string os_name    = Environment.get_os_info ("NAME");
-    string os_version = Environment.get_os_info ("VERSION");
+    string os_name    = Environment.get_os_info ("NAME") ?? _("UNKNOWN");
+    string os_version = (Environment.get_os_info ("VERSION") ?? Environment.get_os_info ("VERSION_ID"))
+                        ?? _("UNKNOWN");
     bool   in_flatpak = FileUtils.test ("/.flatpak-info", EXISTS);
 
     info_string += "System:\n";


### PR DESCRIPTION
openSUSE Tumbleweed has a `VERSION_ID` but no `VERSION`. The docs say that all variables are optional. Use null-coalescing to try fallbacks and set default "UNKNOWN" values.