### PR TITLE
Auto-refresh timeline

### DIFF
--- a/lib/Base/Organization/Collection.vala
+++ b/lib/Base/Organization/Collection.vala
@@ -47,6 +47,14 @@ public abstract class Backend.Collection : Object {
    */
   public abstract async void pull_posts () throws Error;
 
+  protected virtual void add_posts (Backend.Post[] posts) {
+    // Load the posts in the post list
+    var store = post_list as ListStore;
+    foreach (Backend.Post post in posts) {
+      store.insert_sorted (post, compare_items);
+    }
+  }
+
   /**
    * Checks if a post in the list replies to the post previous to it.
    *
@@ -198,10 +206,4 @@ public abstract class Backend.Collection : Object {
     }
     return post;
   }
-
-  /**
-   * The id from the latest pulled Post.
-   */
-  protected string? last_post_id = null;
-
 }

--- a/lib/Base/Organization/ExpandableCollection.vala
+++ b/lib/Base/Organization/ExpandableCollection.vala
@@ -1,0 +1,71 @@
+/* ExpandableCollection.vala
+ *
+ * Copyright 2023 IBBoard
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+ using GLib;
+
+ /**
+  * Base class for collections of Posts that can load newer and older posts.
+  */
+ public abstract class Backend.ExpandableCollection : Backend.Collection {
+    public override async void pull_posts () throws Error {
+        yield pull_newer_posts ();
+    }
+
+    /**
+     * Calls the API to get the newest posts for the Collection.
+     *
+     * @throws Error Any error that happened while pulling the posts.
+     */
+    public abstract async void pull_newer_posts () throws Error;
+
+    /**
+     * Calls the API to get older posts for the Collection.
+     *
+     * @throws Error Any error that happened while pulling the posts.
+     */
+    public abstract async void pull_older_posts () throws Error;
+
+    /**
+     * The id from the latest pulled Post.
+     */
+    protected string? last_post_id = null;
+
+    /**
+     * The id from the oldest pulled Post.
+     */
+    protected string? first_post_id = null;
+
+    protected override void add_posts (Backend.Post[] posts) {
+      // Load the posts in the post list
+      var store = post_list as ListStore;
+      foreach (Backend.Post post in posts) {
+        store.insert_sorted (post, compare_items);
+        // Mastodon IDs are "cast from an integer but not guaranteed to be a number",
+        // Twitter "snowflake" IDs are a timestamp with extra information packed on the end,
+        // so we assume that IDs are orderable
+        if (last_post_id == null || post.id > last_post_id) {
+          last_post_id = post.id;
+        }
+        if (first_post_id == null || post.id < first_post_id) {
+          first_post_id = post.id;
+        }
+      }
+    }
+ }

--- a/lib/Base/Organization/HomeTimeline.vala
+++ b/lib/Base/Organization/HomeTimeline.vala
@@ -23,7 +23,7 @@ using GLib;
 /**
  * The reverse chronological timeline with posts from all followed users.
  */
-public abstract class Backend.HomeTimeline : Backend.Collection {
+public abstract class Backend.HomeTimeline : Backend.ExpandableCollection {
 
   /**
    * The Account which timeline is presented.

--- a/lib/Base/Organization/UserTimeline.vala
+++ b/lib/Base/Organization/UserTimeline.vala
@@ -23,7 +23,7 @@ using GLib;
 /**
  * The timeline of Posts a certain User has created.
  */
-public abstract class Backend.UserTimeline : Backend.Collection {
+public abstract class Backend.UserTimeline : Backend.ExpandableCollection {
 
   /**
    * The User which timeline is presented.

--- a/lib/Mastodon/Organization/HomeTimeline.vala
+++ b/lib/Mastodon/Organization/HomeTimeline.vala
@@ -80,6 +80,11 @@ public class Backend.Mastodon.HomeTimeline : Backend.HomeTimeline {
     var store = post_list as ListStore;
     foreach (Backend.Post post in session.load_post_list (json)) {
       store.insert_sorted (post, compare_items);
+      if (post.id > last_post_id) {
+        // Mastodon IDs are "cast from an integer but not guaranteed to be a number",
+        // so assume they're orderable and the latest one is the last post ID
+        last_post_id = post.id;
+      }
     }
   }
 

--- a/lib/Mastodon/Organization/HomeTimeline.vala
+++ b/lib/Mastodon/Organization/HomeTimeline.vala
@@ -52,20 +52,24 @@ public class Backend.Mastodon.HomeTimeline : Backend.HomeTimeline {
       header_i++;
     }
   }
-  
-  /**
-   * Calls the API to get the posts for the Collection.
-   *
-   * @throws Error Any error that happened while pulling the posts.
-   */
-  public override async void pull_posts () throws Error {
+
+  public override async void pull_newer_posts () throws Error {
+    yield pull_posts_with_anchor ("min_id", last_post_id);
+  }
+
+  public override async void pull_older_posts () throws Error {
+    yield pull_posts_with_anchor ("max_id", first_post_id);
+  }
+
+  private async void pull_posts_with_anchor(string? key, string? value) throws Error {
+    debug("Pulling Mastodon home posts with %s=%s", key, value);
     // Create the proxy call
     Rest.ProxyCall call = session.create_call ();
     call.set_method ("GET");
     call.set_function (@"api/v1/timelines/home");
     call.add_param ("limit", "50");
-    if (last_post_id != null) {
-      call.add_param ("min_id", last_post_id);
+    if (key != null && value != null) {
+      call.add_param (key, value);
     }
 
     // Load the timeline
@@ -77,15 +81,7 @@ public class Backend.Mastodon.HomeTimeline : Backend.HomeTimeline {
     }
 
     // Load the posts in the post list
-    var store = post_list as ListStore;
-    foreach (Backend.Post post in session.load_post_list (json)) {
-      store.insert_sorted (post, compare_items);
-      if (post.id > last_post_id) {
-        // Mastodon IDs are "cast from an integer but not guaranteed to be a number",
-        // so assume they're orderable and the latest one is the last post ID
-        last_post_id = post.id;
-      }
-    }
+    add_posts (session.load_post_list (json));
   }
 
 }

--- a/lib/Mastodon/Organization/UserTimeline.vala
+++ b/lib/Mastodon/Organization/UserTimeline.vala
@@ -54,12 +54,16 @@ public class Backend.Mastodon.UserTimeline : Backend.UserTimeline {
     }
   }
 
-  /**
-   * Calls the API to get the posts for the Collection.
-   *
-   * @throws Error Any error that happened while pulling the posts.
-   */
-  public override async void pull_posts () throws Error {
+  public override async void pull_newer_posts () throws Error {
+    yield pull_posts_with_anchor ("min_id", last_post_id);
+  }
+
+  public override async void pull_older_posts () throws Error {
+    yield pull_posts_with_anchor ("max_id", first_post_id);
+  }
+
+  private async void pull_posts_with_anchor(string? key, string? value) throws Error {
+    debug("Pulling Mastodon user posts with %s=%s", key, value);
     // Create the proxy call
     Rest.ProxyCall call = session.create_call ();
     call.set_method ("GET");
@@ -78,10 +82,7 @@ public class Backend.Mastodon.UserTimeline : Backend.UserTimeline {
     }
 
     // Load the posts in the post list
-    var store = post_list as ListStore;
-    foreach (Backend.Post post in session.load_post_list (json)) {
-      store.insert_sorted (post, compare_items);
-    }
+    add_posts (session.load_post_list (json));
   }
 
 }

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -26,6 +26,7 @@ libfiles = [
   'Base/Content/UserDataField.vala',
   'Base/Content/UserEnums.vala',
   'Base/Organization/Collection.vala',
+  'Base/Organization/ExpandableCollection.vala',
   'Base/Organization/HomeTimeline.vala',
   'Base/Organization/PseudoItem.vala',
   'Base/Organization/Thread.vala',

--- a/src/Content/CollectionView.vala
+++ b/src/Content/CollectionView.vala
@@ -463,7 +463,6 @@ public class RefreshingCollectionView : CollectionView {
 
   private bool poll_for_posts() {
     pull_posts ();
-    refresh_source_id = Timeout.add_seconds (poll_interval, poll_for_posts, 0);
     return true;
   }
 }

--- a/src/Content/CollectionView.vala
+++ b/src/Content/CollectionView.vala
@@ -126,7 +126,6 @@ public class CollectionView : Gtk.Widget {
    * Run at construction of an widget.
    */
   construct {
-    debug("Construct(CollectionView) for %s", this.get_type ().name ());
     // Create a list filter from the collection
     list_filter = new Gtk.CustomFilter (filter_items);
 
@@ -435,8 +434,6 @@ public class RefreshingCollectionView : CollectionView {
   public double scroll_end_offset {get; set; default = 200;}
 
   construct {
-    debug("Construct(RefreshCollectionView) for %s", this.get_type ().name ());
-
     // Backfill old posts as we scroll
     scroll_window.vadjustment.value_changed.connect (() => {
       double max = scroll_window.vadjustment.upper - scroll_window.vadjustment.page_size;

--- a/src/Pages/MainPage.vala
+++ b/src/Pages/MainPage.vala
@@ -34,7 +34,7 @@ public class MainPage : Gtk.Widget {
   [GtkChild]
   private unowned Adw.WindowTitle content_title;
   [GtkChild]
-  private unowned CollectionView home_collection;
+  private unowned RefreshingCollectionView home_collection;
 
   // UI-Elements of the flap
   [GtkChild]

--- a/src/Pages/UserPage.vala
+++ b/src/Pages/UserPage.vala
@@ -32,7 +32,7 @@ public class UserPage : Gtk.Widget {
   [GtkChild]
   private unowned Adw.WindowTitle page_title;
   [GtkChild]
-  private unowned CollectionView collection_view;
+  private unowned RefreshingCollectionView collection_view;
 
   /**
    * The User which is displayed.

--- a/ui/Pages/MainPage.blp
+++ b/ui/Pages/MainPage.blp
@@ -32,7 +32,7 @@ template MainPage : Gtk.Widget {
         }
       }
 
-      .CollectionView home_collection {
+      .RefreshingCollectionView home_collection {
         vexpand: true;
       }
     }

--- a/ui/Pages/UserPage.blp
+++ b/ui/Pages/UserPage.blp
@@ -17,7 +17,7 @@ template UserPage : Gtk.Widget {
     Adw.WindowTitle page_title {}
   }
 
-  .CollectionView collection_view {
+  .RefreshingCollectionView collection_view {
     header: .UserDisplay {
       user: bind UserPage.user;
     };


### PR DESCRIPTION
Some structural changes and timeouts to give us auto-updating timelines that poll for new messages every two minutes.

Also implements the "load older on scroll back" behaviour.

I'm not sure of the balance between "file per class" and "minor extension classes just go in the same file", so I can refactor if there's a preference.